### PR TITLE
fixed javadoc error: self-closing element not allowed

### DIFF
--- a/src/main/java/com/lemmingapex/trilateration/LinearLeastSquaresSolver.java
+++ b/src/main/java/com/lemmingapex/trilateration/LinearLeastSquaresSolver.java
@@ -4,9 +4,9 @@ import org.apache.commons.math3.linear.*;
 
 /**
  * FIXME: Testing a linear approach...
- * <p/>
+ * <p>
  * Solves a Trilateration problem
- * <p/>
+ * </p>
  * see http://inside.mines.edu/~whereman/talks/TurgutOzal-11-Trilateration.pdf
  *
  * @author scott


### PR DESCRIPTION
When I tried to compile the project with:

```
./gradlew build
```

I got the following error:

```
:compileJava
:processResources UP-TO-DATE
:classes
:jar
:javadocC:\Users\Hamza\Desktop\Trilateration-master\Trilateration-master\src\main\java\com\lemmingapex\trilateration\LinearLeastSquaresSolver.java:7: error: self-closing element not allowed
 * <p/>
   ^
C:\Users\Hamza\Desktop\Trilateration-master\Trilateration-master\src\main\java\com\lemmingapex\trilateration\LinearLeastSquaresSolver.java:9: error: self-closing element not allowed
 * <p/>
   ^

2 errors
:javadoc FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':javadoc'.
> Javadoc generation failed. Generated Javadoc options file (useful for troubleshooting): 'C:\Users\Hamza\Desktop\Trilateration-master\Trilateration-master\build\tmp\javadoc\javadoc.options'

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 5.091 secs
```

This should fix the error.
